### PR TITLE
ci(workflow): 更新release.yml中的token配置

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -84,7 +84,7 @@ jobs:
           echo "[pypi]" > ~/.pypirc
           echo "username = __token__" >> ~/.pypirc
           echo "password = $PYPI_TOKEN" >> ~/.pypirc
-          
+
           # Run semantic-release
           npx semantic-release
 


### PR DESCRIPTION
将GITHUB_TOKEN替换为SEMANTIC_RELEASE_TOKEN以适配语义化发布流程